### PR TITLE
refactor: update timezones selector to include UTC offsets

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,10 @@ import FromISO from '@/components/from-iso'
 
 export default function Page() {
   const currentDate: Date = new Date();
-  const timezones: Array<string> = moment.tz.names();
+  const timezones: Array<{ name: string, utc: string }> = moment.tz.names().map(tz => {
+    const utcOffset = moment.tz(tz).format('Z');
+    return { name: tz, utc: `UTC${utcOffset}` };
+  });
   const initCurrentTz: string = moment.tz.guess();
   const initCurrentTimestamp = moment(currentDate).tz(initCurrentTz);
   const initCurrentDatetime = moment(currentDate).tz(initCurrentTz);

--- a/components/timezone-selector.tsx
+++ b/components/timezone-selector.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/popover"
 
 interface Props {
-  timezones: Array<string>,
+  timezones: Array<{ name: string, utc: string }>,
   currentTz: string,
   setCurrentTz: Function
 }
@@ -41,13 +41,24 @@ export default function TimezoneSelector({ timezones, currentTz, setCurrentTz }:
           className="w-full justify-between"
         >
           {value
-            ? timezones.find((timezone) => timezone === value)
+            ? timezones.map((timezone) => {
+              if (timezone.name === value) {
+                return timezone.utc + " " + timezone.name;
+              }
+            } )
             : currentTz}
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-full p-0">
-        <Command>
+      <PopoverContent className="w-full p-5">
+        <Command
+          filter={(value, search) => {
+            if (value.toLowerCase().includes(search.toLowerCase())) {
+              return 1
+            }
+            return 0
+          }}
+        >
           <CommandInput placeholder="Search timezone..." />
           <CommandList>
             <CommandEmpty>No timezone found.</CommandEmpty>
@@ -55,8 +66,9 @@ export default function TimezoneSelector({ timezones, currentTz, setCurrentTz }:
               {timezones.map((timezone, index) => (
                 <CommandItem
                   key={index}
-                  value={timezone}
+                  value={timezone.utc + "%%" + timezone.name}
                   onSelect={(currentValue) => {
+                    currentValue = currentValue.split("%%")[1]
                     setValue(currentValue === value ? "" : currentValue)
                     setCurrentTz(currentValue === value ? "" : currentValue)
                     setOpen(false)
@@ -65,10 +77,10 @@ export default function TimezoneSelector({ timezones, currentTz, setCurrentTz }:
                   <Check
                     className={cn(
                       "mr-2 h-4 w-4",
-                      value === timezone ? "opacity-100" : "opacity-0"
+                      value === timezone.name ? "opacity-100" : "opacity-0"
                     )}
                   />
-                  {timezone}
+                  {`${timezone.utc} ${timezone.name}`}
                 </CommandItem>
               ))}
             </CommandGroup>


### PR DESCRIPTION
#35 

Couldn't get the popover to go full width—I'll give it another shot later since I'm busy with something else right now. Got the UTC offset values added, and the search bar now supports searching with them too.